### PR TITLE
Manual implementation of PartialEq for Code

### DIFF
--- a/src/country.rs
+++ b/src/country.rs
@@ -18,7 +18,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::str;
 use strum::{AsRefStr, EnumString};
 
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Hash, Debug)]
 pub struct Code {
     /// The country code value.
     pub(crate) value: u16,
@@ -26,6 +26,18 @@ pub struct Code {
     /// The source from which the country code is derived.
     pub(crate) source: Source,
 }
+
+impl PartialEq for Code {
+    /// Compare two country codes.
+    ///
+    /// This implementation is necessary because the `source` field is not
+    /// relevant for equality.
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Eq for Code {}
 
 /// The source from which the country code is derived. This is not set in the
 /// general parsing method, but in the method that parses and keeps raw_input.

--- a/src/country.rs
+++ b/src/country.rs
@@ -15,10 +15,10 @@
 //! Country related types.
 
 use serde_derive::{Deserialize, Serialize};
-use std::str;
+use std::{hash::Hash, str};
 use strum::{AsRefStr, EnumString};
 
-#[derive(Copy, Clone, Serialize, Deserialize, Hash, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
 pub struct Code {
     /// The country code value.
     pub(crate) value: u16,
@@ -38,6 +38,16 @@ impl PartialEq for Code {
 }
 
 impl Eq for Code {}
+
+impl Hash for Code {
+    /// Hash the country code.
+    ///
+    /// This implementation is necessary because the `source` field is not
+    /// relevant for hashing, and this should be consistent with Eq/PartialEq.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state)
+    }
+}
 
 /// The source from which the country code is derived. This is not set in the
 /// general parsing method, but in the method that parses and keeps raw_input.

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -333,8 +333,14 @@ mod test {
         };
 
         let formatted = number.format().mode(mode).to_string();
+
+        if mode == Mode::National && country_hint.is_none() {
+            // If we are in national mode, we need to have a country hint
+            return Ok(());
+        }
+
         let parsed = parser::parse(country_hint, &formatted).with_context(|| {
-            format!("parsing {number} after formatting in {mode:?} mode as {formatted}")
+            format!("parsing {number} with country hint {country_hint:?} after formatting in {mode:?} mode as {formatted}")
         })?;
 
         // impl Eq for PhoneNumber does not consider differently parsed phone numbers to be equal.
@@ -352,5 +358,13 @@ mod test {
         #[case] r#type: Type,
     ) {
         assert_eq!(r#type, number.number_type());
+    }
+
+    #[test]
+    fn equality() {
+        let a = crate::parse(None, "+32474091150").unwrap();
+        let b = crate::parse(Some(BE), "0474091150").unwrap();
+
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Fix #55 and #28 

We go from 16 failed round-trip parsing cases to 4.

Previous:
```
    phone_number::test::round_trip_parsing::case_02::mode_4
    phone_number::test::round_trip_parsing::case_03::mode_4
    phone_number::test::round_trip_parsing::case_04::mode_4
    phone_number::test::round_trip_parsing::case_05::mode_4
    phone_number::test::round_trip_parsing::case_06::mode_4
    phone_number::test::round_trip_parsing::case_07::mode_4
    phone_number::test::round_trip_parsing::case_08::mode_1
    phone_number::test::round_trip_parsing::case_08::mode_4
    phone_number::test::round_trip_parsing::case_09::mode_1
    phone_number::test::round_trip_parsing::case_09::mode_4
    phone_number::test::round_trip_parsing::case_10::mode_1
    phone_number::test::round_trip_parsing::case_10::mode_4
    phone_number::test::round_trip_parsing::case_11::mode_1
    phone_number::test::round_trip_parsing::case_11::mode_4
```

Current (only cases pertaining to #46 still remain!):

```
---- phone_number::test::round_trip_parsing::case_10::mode_1 stdout ----
-------------- TEST START --------------
Error: parsing +15208782491 with country hint None after formatting in International mode as +1 520-878-2491

Caused by:
    invalid country code

---- phone_number::test::round_trip_parsing::case_08::mode_1 stdout ----
-------------- TEST START --------------
Error: parsing +13459492311 with country hint None after formatting in International mode as +1 345-949-2311

Caused by:
    invalid country code

---- phone_number::test::round_trip_parsing::case_11::mode_1 stdout ----
-------------- TEST START --------------
Error: parsing +15208782491 with country hint None after formatting in International mode as +1 520-878-2491

Caused by:
    invalid country code

---- phone_number::test::round_trip_parsing::case_09::mode_1 stdout ----
-------------- TEST START --------------
Error: parsing +16137827274 with country hint None after formatting in International mode as +1 613-782-7274

Caused by:
    invalid country code


failures:
    phone_number::test::round_trip_parsing::case_08::mode_1
    phone_number::test::round_trip_parsing::case_09::mode_1
    phone_number::test::round_trip_parsing::case_10::mode_1
    phone_number::test::round_trip_parsing::case_11::mode_1
```

This breaks public API, so this is 0.4 material. I have some things up queue for one more 0.3 release, so let's wait a bit to merge this.