### PR TITLE
Return unparseable country code as error instead of silent failure

### DIFF
--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -299,7 +299,10 @@ mod test {
         #[case] country: Option<country::Id>,
         #[case] _type: Type,
     ) -> anyhow::Result<()> {
-        assert_eq!(country, number.country().id());
+        // Flatten the error into an Option.
+        // XXX: We can't currently distinguish an error case from an unavailable case, given the
+        // current phone number list in rstest above.
+        assert_eq!(country, number.country().id().ok().flatten());
 
         Ok(())
     }

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -236,8 +236,12 @@ impl<'a> Country<'a> {
         self.0.code.value()
     }
 
-    pub fn id(&self) -> Option<country::Id> {
-        self.0.metadata(&DATABASE).and_then(|m| m.id().parse().ok())
+    pub fn id(&self) -> Result<Option<country::Id>, crate::error::Parse> {
+        self.0
+            .metadata(&DATABASE)
+            .map(|m| m.id().parse())
+            .transpose()
+            .map_err(|_e| crate::error::Parse::InvalidCountryCode)
     }
 }
 


### PR DESCRIPTION
Overrides the behaviour of https://github.com/whisperfish/rust-phonenumber/pull/54

Cc @regismesquita @costaraphael, do you think this is an appropriate error, or should we propagate the unparsable `id()` call too?

Fixes #56 