### PR TITLE
Disallow whitespace per RFC3966

### DIFF
--- a/src/parser/rfc3966.rs
+++ b/src/parser/rfc3966.rs
@@ -24,6 +24,11 @@ use nom::{
 };
 
 pub fn phone_number(i: &str) -> IResult<&str, Number<'_>> {
+    // Per RFC3966, spaces are not allowed as separators.
+    if i.contains(' ') {
+        return Err(nom::Err::Error(make_error(i, ErrorKind::Tag)));
+    }
+
     parse! { i =>
         opt(tag_no_case("Tel:"));
         let prefix = opt(prefix);

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -27,7 +27,7 @@ proptest! {
     }
 
     // Issue #83: `parse` returns an error when parsing "+1 650-253-0000".
-    // Reason: the number was parsed using RFC 3966 rules, incorretly parsing the prefix as 
+    // Reason: the number was parsed using RFC 3966 rules, incorrectly parsing the prefix as
     // "+1 650". A space should not be allowed in an RFC 3966 number, and the regex based parser
     // should be used instead.
     #[test]

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -26,6 +26,16 @@ proptest! {
         let _ = parse(None, &s);
     }
 
+    // Issue #83: `parse` returns an error when parsing "+1 650-253-0000".
+    // Reason: the number was parsed using RFC 3966 rules, incorretly parsing the prefix as 
+    // "+1 650". A space should not be allowed in an RFC 3966 number, and the regex based parser
+    // should be used instead.
+    #[test]
+    fn parse_mixed_spaces_and_dashes(s in "\\+1[ -]650[ -]253[ -]0000") {
+        let parsed = parse(None, &s).unwrap();
+        prop_assert_eq!(parsed.country().id(), phonenumber::country::US.into());
+    }
+
     #[test]
     fn parse_belgian_phonenumbers(s in "\\+32[0-9]{8,9}") {
         let parsed = parse(None, &s).expect("valid Belgian number");


### PR DESCRIPTION
No whitespace character appears in the syntax described in RFC3966.

Previously, "+1 650-253-0000" was parsed, but panicked later when validating the number. It parsed "+1 650" as the prefix, which is not a valid prefix. Disallowing whitespace here prevents parsing the phone number using the RFC3966 format. Instead, the regex based parser is used.

Fixes #83