### PR TITLE
fix: metadata validator requires national number without leading zero

### DIFF
--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// The national number part of a phone number.
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub struct NationalNumber {
-    pub(crate) value: u64,
+    value: u64,
 }
 
 impl NationalNumber {

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -282,11 +282,12 @@ mod test {
     #[case(parsed("+16137827274"), Some(CA), Type::FixedLineOrMobile)]
     #[case(parsed("+1 520 878 2491"), Some(US), Type::FixedLineOrMobile)]
     #[case(parsed("+1-520-878-2491"), Some(US), Type::FixedLineOrMobile)]
+    #[case(parsed("+1 520-878-2491"), Some(US), Type::FixedLineOrMobile)]
+    #[case(parsed("+1 800 723 3456"), Some(US), Type::TollFree)] // issue #46
+    #[case(parsed("+1 800-723-3456"), Some(US), Type::TollFree)] // issue #46
+    #[case(parsed("+1-800-723-3456"), Some(US), Type::TollFree)] // issue #46
+    #[case(parsed("+1 520-878-2491"), Some(US), Type::FixedLineOrMobile)] // issue #47
     #[case(parsed("+330631966543"), Some(FR), Type::Mobile)]
-    // Case for issues
-    // https://github.com/whisperfish/rust-phonenumber/issues/46 and
-    // https://github.com/whisperfish/rust-phonenumber/issues/47
-    // #[case(parsed("+1 520-878-2491"), US)]
     fn phone_numbers(
         #[case] number: PhoneNumber,
         #[case] country: Option<country::Id>,

--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -206,7 +206,11 @@ impl PhoneNumber {
     /// Get the metadata that applies to this phone number from the given
     /// database.
     pub fn metadata<'a>(&self, database: &'a Database) -> Option<&'a Metadata> {
-        match validator::source_for(database, self.code.value(), &self.national.to_string())? {
+        match validator::source_for(
+            database,
+            self.code.value(),
+            &self.national.value().to_string(),
+        )? {
             Left(region) => database.by_id(region.as_ref()),
             Right(code) => database.by_code(&code).and_then(|m| m.into_iter().next()),
         }
@@ -225,7 +229,7 @@ impl PhoneNumber {
     /// Determine the [`Type`] of the phone number.
     pub fn number_type(&self, database: &Database) -> Type {
         match self.metadata(database) {
-            Some(metadata) => validator::number_type(metadata, &self.national.value.to_string()),
+            Some(metadata) => validator::number_type(metadata, &self.national.value().to_string()),
             None => Type::Unknown,
         }
     }
@@ -278,6 +282,7 @@ mod test {
     #[case(parsed("+16137827274"), Some(CA), Type::FixedLineOrMobile)]
     #[case(parsed("+1 520 878 2491"), Some(US), Type::FixedLineOrMobile)]
     #[case(parsed("+1-520-878-2491"), Some(US), Type::FixedLineOrMobile)]
+    #[case(parsed("+330631966543"), Some(FR), Type::Mobile)]
     // Case for issues
     // https://github.com/whisperfish/rust-phonenumber/issues/46 and
     // https://github.com/whisperfish/rust-phonenumber/issues/47


### PR DESCRIPTION
The validator for the number type first does a check with the following regex `"[1-9]\\d{8}"`. We should pass the national (significant) number to the validator instead of the number with the leading zero.