### PR TITLE
Fix parse national prefix with zero

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -266,6 +266,45 @@ mod test {
     use crate::parser;
 
     #[test]
+    fn fr_leading_zero() {
+        assert_eq!(
+            "06 31 96 65 43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::National)
+                .to_string()
+        );
+
+        assert_eq!(
+            "+33 6 31 96 65 43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::International)
+                .to_string()
+        );
+
+        assert_eq!(
+            "+33631966543",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::E164)
+                .to_string()
+        );
+
+        assert_eq!(
+            "tel:+33-6-31-96-65-43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::Rfc3966)
+                .to_string()
+        );
+    }
+
+    #[test]
     fn us() {
         assert_eq!(
             "(650) 253-0000",

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -325,6 +325,14 @@ mod test {
         ));
 
         assert!(validator::is_valid(
+            &parser::parse(Some(country::FR), "+330631966543").unwrap()
+        ));
+
+        assert!(validator::is_valid(
+            &parser::parse(None, "+330631966543").unwrap()
+        ));
+
+        assert!(validator::is_valid(
             &parser::parse(Some(country::GB), "+44 7912345678").unwrap()
         ));
 


### PR DESCRIPTION
Fixes the parsing of phone numbers with a leading 0 after the country code, such as "+330631966543".

The parsing does not fail when doing:
`parse(Some(country::FR), "+330631966543")`

However, it does fail when the country code is not passed to it:
`parse(None, "+330631966543")`

When the country code is not passed to it, then the following block is not executed (which removes the national prefix when present):
```rust
    // Extract carrier and strip national prefix if present.
    if let Some(meta) = country.and_then(|c| database.by_id(c.as_ref())) {
        let mut potential = helper::national_number(meta, number.clone());


        // Strip national prefix if present.
        if let Some(prefix) = meta.national_prefix.as_ref() {
            if potential.national.starts_with(prefix) {
                potential.national = helper::trim(potential.national, prefix.len());
            }
        }


        if validator::length(meta, &potential, Type::Unknown) != Validation::TooShort {
            number = potential;
        }
    }
```

When parsing the number, we should find out what the country code is and then strip the national prefix, which is what this PR does. However, I'm not satisfied with how it turns out since detecting the country code is now duplicated. Normally, getting the country code is done with the `Country` helper struct that takes a `&PhoneNumber`.

This PR also adds a test case for the formatting of numbers with a national prefix.

Fixes #81 