### PR TITLE
Fix parsing of national prefix with zero

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -266,6 +266,45 @@ mod test {
     use crate::parser;
 
     #[test]
+    fn fr_leading_zero() {
+        assert_eq!(
+            "06 31 96 65 43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::National)
+                .to_string()
+        );
+
+        assert_eq!(
+            "+33 6 31 96 65 43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::International)
+                .to_string()
+        );
+
+        assert_eq!(
+            "+33631966543",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::E164)
+                .to_string()
+        );
+
+        assert_eq!(
+            "tel:+33-6-31-96-65-43",
+            parser::parse(Some(country::FR), "+330631966543")
+                .unwrap()
+                .format()
+                .mode(Mode::Rfc3966)
+                .to_string()
+        );
+    }
+
+    #[test]
     fn us() {
         assert_eq!(
             "(650) 253-0000",

--- a/src/national_number.rs
+++ b/src/national_number.rs
@@ -13,12 +13,23 @@
 // limitations under the License.
 
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 /// The national number part of a phone number.
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, Debug)]
 pub struct NationalNumber {
     value: u64,
+}
+
+impl FromStr for NationalNumber {
+    type Err = crate::error::Parse;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let zeros = s.chars().take_while(|&c| c == '0').count();
+        let value = s[zeros..].parse::<u64>()?;
+
+        NationalNumber::new(value, zeros as u8)
+    }
 }
 
 impl NationalNumber {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,7 +18,6 @@ use crate::country;
 use crate::error;
 use crate::extension::Extension;
 use crate::metadata::{Database, DATABASE};
-use crate::national_number::NationalNumber;
 use crate::phone_number::{PhoneNumber, Type};
 use crate::validator::{self, Validation};
 use nom::{branch::alt, IResult};
@@ -53,32 +52,27 @@ pub fn parse_with<S: AsRef<str>>(
     // Normalize the number and extract country code.
     number = helper::country_code(database, country, number)?;
 
-    let country = if country.is_none() {
-        // If no country was supplied, try to determine it from the number.
-        // We need to determine the country to be able to strip the national prefix if present.
+    // If no country was supplied, try to determine the metadata from the number.
+    // We need to determine the country to be able to classify the national prefix if present.
+    let meta = if let Some(country) = &country {
+        database.by_id(country.as_ref())
+    } else {
         let code = country::Code {
             value: number.prefix.clone().map(|p| p.parse()).unwrap_or(Ok(0))?,
             source: number.country,
         };
 
-        let national = NationalNumber::new(
-            number.national.parse()?,
-            number.national.chars().take_while(|&c| c == '0').count() as u8,
-        )?;
-
         use either::{Left, Right};
-        match validator::source_for(database, code.value(), &national.value().to_string()) {
+        let without_zeros = number.national.trim_start_matches('0');
+        match validator::source_for(database, code.value(), without_zeros) {
             Some(Left(region)) => database.by_id(region.as_ref()),
             Some(Right(code)) => database.by_code(&code).and_then(|m| m.into_iter().next()),
             None => None,
         }
-        .and_then(|m| m.id().parse().ok())
-    } else {
-        country
     };
 
     // Extract carrier and strip national prefix if present.
-    if let Some(meta) = country.and_then(|c| database.by_id(c.as_ref())) {
+    if let Some(meta) = meta {
         let mut potential = helper::national_number(meta, number.clone());
 
         // Strip national prefix if present.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -107,10 +107,7 @@ pub fn parse_with<S: AsRef<str>>(
             source: number.country,
         },
 
-        national: NationalNumber::new(
-            number.national.parse()?,
-            number.national.chars().take_while(|&c| c == '0').count() as u8,
-        )?,
+        national: number.national.parse()?,
 
         extension: number.extension.map(|s| Extension(s.into_owned())),
         carrier: number.carrier.map(|s| Carrier(s.into_owned())),

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -325,6 +325,14 @@ mod test {
         ));
 
         assert!(validator::is_valid(
+            &parser::parse(Some(country::FR), "+330631966543").unwrap()
+        ));
+
+        assert!(validator::is_valid(
+            &parser::parse(None, "+330631966543").unwrap()
+        ));
+
+        assert!(validator::is_valid(
             &parser::parse(Some(country::GB), "+44 7912345678").unwrap()
         ));
 


### PR DESCRIPTION
Fixes the parsing of phone numbers with a leading 0 after the country code, such as "+330631966543".

The parsing does not fail when doing:
`parse(Some(country::FR), "+330631966543")`

However, it does fail when the country code is not passed to it:
`parse(None, "+330631966543")`

When the country code is not passed to it, then the following block is not executed (which removes the national prefix when present):
```rust
    // Extract carrier and strip national prefix if present.
    if let Some(meta) = country.and_then(|c| database.by_id(c.as_ref())) {
        let mut potential = helper::national_number(meta, number.clone());


        // Strip national prefix if present.
        if let Some(prefix) = meta.national_prefix.as_ref() {
            if potential.national.starts_with(prefix) {
                potential.national = helper::trim(potential.national, prefix.len());
            }
        }


        if validator::length(meta, &potential, Type::Unknown) != Validation::TooShort {
            number = potential;
        }
    }
```

When parsing the number, we should find out what the country code is and then strip the national prefix, which is what this PR does. However, I'm not satisfied with how it turns out since detecting the country code is now duplicated. Normally, getting the country code is done with the `Country` helper struct that takes a `&PhoneNumber`.

This PR also adds a test case for the formatting of numbers with a national prefix.

Fixes #81 