### PR TITLE
Fix viable phone number and use it in parse logic

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,6 +17,7 @@ use crate::consts;
 use crate::country;
 use crate::error;
 use crate::extension::Extension;
+use crate::is_viable;
 use crate::metadata::{Database, DATABASE};
 use crate::national_number::NationalNumber;
 use crate::phone_number::{PhoneNumber, Type};
@@ -49,6 +50,10 @@ pub fn parse_with<S: AsRef<str>>(
 
     // Try to parse the number as RFC3966 or natural language.
     let (_, mut number) = phone_number(string.as_ref()).or(Err(error::Parse::NoNumber))?;
+
+    if !is_viable(&number.national) {
+        return Err(error::Parse::NoNumber);
+    }
 
     // Normalize the number and extract country code.
     number = helper::country_code(database, country, number)?;
@@ -283,6 +288,12 @@ mod test {
     #[test]
     fn advisory_2() {
         let res = parser::parse(None, "+dwPAA;phone-context=AA");
+        assert!(res.is_err(), "{res:?}");
+    }
+
+    #[test]
+    fn email() {
+        let res = parser::parse(Some(country::US), "someletters1110@gmail.com");
         assert!(res.is_err(), "{res:?}");
     }
 }

--- a/src/parser/valid.rs
+++ b/src/parser/valid.rs
@@ -29,11 +29,18 @@ fn short(i: &str) -> IResult<&str, ()> {
 }
 
 fn long(i: &str) -> IResult<&str, ()> {
+    fn first_group(i: &str) -> IResult<&str, ()> {
+        parse! { i =>
+            many0(alt((punctuation, star)));
+            count(digit, 1);
+        };
+        Ok((i, ()))
+    }
+
     parse! { i =>
         many0(plus);
-        many0(alt((punctuation, star)));
-        count(digit, 3);
-        many0(digit);
+        count(first_group, 3);
+        many0(alt((punctuation, star, digit)));
         many0(alt((punctuation, star, digit, alpha)));
         ieof;
     };
@@ -61,5 +68,7 @@ mod test {
         assert!(phone_number("08-PIZZA").is_err());
         assert!(phone_number("8-PIZZA").is_err());
         assert!(phone_number("12. March").is_err());
+        // E-mail addresses are not phone numbers.
+        assert!(phone_number("1110@gmail.com").is_err());
     }
 }

--- a/src/parser/valid.rs
+++ b/src/parser/valid.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::parser::helper::*;
+use crate::{consts, parser::helper::*};
 use nom::{branch::*, combinator::*, multi::*, IResult};
 
 pub fn phone_number(i: &str) -> IResult<&str, &str> {
@@ -21,7 +21,7 @@ pub fn phone_number(i: &str) -> IResult<&str, &str> {
 
 fn short(i: &str) -> IResult<&str, ()> {
     parse! { i =>
-        count(digit, 2);
+        count(digit, consts::MIN_LENGTH_FOR_NSN);
         ieof;
     };
 


### PR DESCRIPTION
Fix the check for a valid phone number and use `is_viable` when parsing.

The regex from the java implementation for checking if a phone number is viable is

```
DIGITS + "{" + MIN_LENGTH_FOR_NSN + "}" + "|"
      + "[" + PLUS_CHARS + "]*+(?:[" + VALID_PUNCTUATION + STAR_SIGN + "]*" + DIGITS + "){3,}["
      + VALID_PUNCTUATION + STAR_SIGN + VALID_ALPHA + DIGITS + "]*";
```

Previously, we were checking if we had 3 consecutive digits before alpha characters. However, between these numbers there could be punctuations as well. Which this PR fixes.

Furthermore, I added the `is_viable` function to the parse logic such that we only continue parsing viable phone numbers, which fixes #80.

