### PR TITLE
add number_type_with_default_db which allows to get a number type without providing any database and rely on the default one

### DIFF
--- a/src/phone_number.rs
+++ b/src/phone_number.rs
@@ -233,6 +233,11 @@ impl PhoneNumber {
             None => Type::Unknown,
         }
     }
+
+    /// Determine the [`Type`] of the phone number.
+    pub fn number_type_with_default_db(&self) -> Type {
+        self.number_type(&DATABASE)
+    }
 }
 
 impl<'a> Country<'a> {


### PR DESCRIPTION
It's hard to check if a phone number is a mobile or a fixed line, because we need to provide a database. There is no way to use the inner default database.
Let's expose that!

Related issue: https://github.com/whisperfish/rust-phonenumber/issues/85