### PR TITLE
Cargo.toml:  Update `strum` to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.7"
 regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-strum = { version = ">=0.24, <=0.26", features = ["derive"] }
+strum = { version = ">=0.24, <=0.27", features = ["derive"] }
 thiserror = "2.0"
 
 [build-dependencies]


### PR DESCRIPTION
Keeping the `>=0.24` bound; just allowing a maximum of 0.27, instead of 0.26.