### PR TITLE
Add carrier name lookup from bundled prefix data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,15 @@ fn main() {
 	}
 }
 ```
+
+## Carrier name lookup
+
+Look up the carrier name for a phone number using the bundled libphonenumber
+prefix data. Supports multiple languages with automatic fallback.
+
+```rust
+use phonenumber::carrier_mapper;
+
+let number = phonenumber::parse(None, "+33600000000").unwrap();
+assert_eq!(carrier_mapper::name_for_number(&number, "en"), Some("Free Mobile"));
+```

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn build_metadata_database() {
     println!("cargo:rerun-if-changed={pnm_path}");
 
     let mut out = BufWriter::new(
-        File::create(Path::new(&env::var("OUT_DIR").unwrap()).join("database.bin"))
+        File::create(Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("database.bin"))
             .expect("could not create database file"),
     );
 
@@ -40,38 +40,27 @@ fn build_carrier_data() {
     let mut entries: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     let mut max_prefix_len: usize = 0;
 
-    if !carrier_dir.is_dir() {
-        // Write empty data if carrier directory is missing.
-        let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("carrier_data.bin");
-        type CarrierEntries = Vec<(String, Vec<(String, String)>)>;
-        let empty: (CarrierEntries, usize) = (Vec::new(), 0);
-        let mut out =
-            BufWriter::new(File::create(&out_path).expect("could not create carrier data file"));
-        postcard::to_io(&empty, &mut out).expect("failed to serialize carrier data");
-        return;
-    }
+    assert!(
+        carrier_dir.is_dir(),
+        "assets/carrier directory is missing — this is a repository bug"
+    );
 
     // Walk each language directory: assets/carrier/en/, assets/carrier/zh/, etc.
     let mut lang_dirs: Vec<_> = fs::read_dir(carrier_dir)
         .expect("could not read carrier directory")
-        .filter_map(|e| e.ok())
+        .map(|e| e.expect("could not read carrier directory entry"))
         .filter(|e| e.path().is_dir())
         .collect();
     lang_dirs.sort_by_key(|e| e.file_name());
 
     for lang_entry in lang_dirs {
-        let lang = lang_entry.file_name().to_string_lossy().to_string();
+        let lang = lang_entry.file_name().to_str().expect("unicode carrier directory").to_string();
         let lang_path = lang_entry.path();
 
         let mut txt_files: Vec<_> = fs::read_dir(&lang_path)
             .unwrap_or_else(|e| panic!("could not read {}: {e}", lang_path.display()))
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .map(|ext| ext == "txt")
-                    .unwrap_or(false)
-            })
+            .map(|e| e.unwrap_or_else(|err| panic!("could not read entry in {}: {err}", lang_path.display())))
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
             .map(|e| e.path())
             .collect();
         txt_files.sort();
@@ -87,16 +76,15 @@ fn build_carrier_data() {
                 if line.is_empty() || line.starts_with('#') {
                     continue;
                 }
-                if let Some((prefix, name)) = line.split_once('|') {
-                    let prefix = prefix.trim();
-                    let name = name.trim();
-                    if !prefix.is_empty() && prefix.bytes().all(|b| b.is_ascii_digit()) {
-                        max_prefix_len = max_prefix_len.max(prefix.len());
-                        entries
-                            .entry(prefix.to_string())
-                            .or_default()
-                            .insert(lang.clone(), name.to_string());
-                    }
+                let (prefix, name) = line.split_once('|').expect("line format");
+                let prefix = prefix.trim();
+                let name = name.trim();
+                if !prefix.is_empty() && prefix.bytes().all(|b| b.is_ascii_digit()) {
+                    max_prefix_len = max_prefix_len.max(prefix.len());
+                    entries
+                        .entry(prefix.to_string())
+                        .or_default()
+                        .insert(lang.clone(), name.to_string());
                 }
             }
         }
@@ -111,7 +99,7 @@ fn build_carrier_data() {
         })
         .collect();
 
-    let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("carrier_data.bin");
+    let out_path = Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("carrier_data.bin");
     let mut out =
         BufWriter::new(File::create(&out_path).expect("could not create carrier data file"));
     postcard::to_io(&(&serializable, max_prefix_len), &mut out)

--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,10 @@ fn build_metadata_database() {
     println!("cargo:rerun-if-changed={pnm_path}");
 
     let mut out = BufWriter::new(
-        File::create(Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("database.bin"))
-            .expect("could not create database file"),
+        File::create(
+            Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("database.bin"),
+        )
+        .expect("could not create database file"),
     );
 
     postcard::to_io(&metadata, &mut out).expect("failed to serialize database");
@@ -54,12 +56,20 @@ fn build_carrier_data() {
     lang_dirs.sort_by_key(|e| e.file_name());
 
     for lang_entry in lang_dirs {
-        let lang = lang_entry.file_name().to_str().expect("unicode carrier directory").to_string();
+        let lang = lang_entry
+            .file_name()
+            .to_str()
+            .expect("unicode carrier directory")
+            .to_string();
         let lang_path = lang_entry.path();
 
         let mut txt_files: Vec<_> = fs::read_dir(&lang_path)
             .unwrap_or_else(|e| panic!("could not read {}: {e}", lang_path.display()))
-            .map(|e| e.unwrap_or_else(|err| panic!("could not read entry in {}: {err}", lang_path.display())))
+            .map(|e| {
+                e.unwrap_or_else(|err| {
+                    panic!("could not read entry in {}: {err}", lang_path.display())
+                })
+            })
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
             .map(|e| e.path())
             .collect();
@@ -67,9 +77,10 @@ fn build_carrier_data() {
 
         for path in txt_files {
             println!("cargo:rerun-if-changed={}", path.display());
-            let file = BufReader::new(File::open(&path).unwrap_or_else(|e| {
-                panic!("could not open {}: {e}", path.display())
-            }));
+            let file = BufReader::new(
+                File::open(&path)
+                    .unwrap_or_else(|e| panic!("could not open {}: {e}", path.display())),
+            );
             for line in file.lines() {
                 let line = line.expect("could not read line");
                 let line = line.trim();
@@ -99,7 +110,8 @@ fn build_carrier_data() {
         })
         .collect();
 
-    let out_path = Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("carrier_data.bin");
+    let out_path =
+        Path::new(&env::var("OUT_DIR").expect("OUT_DIR not set")).join("carrier_data.bin");
     let mut out =
         BufWriter::new(File::create(&out_path).expect("could not create carrier data file"));
     postcard::to_io(&(&serializable, max_prefix_len), &mut out)

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeMap;
 use std::env;
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, BufWriter};
 use std::path::Path;
 
 #[path = "src/metadata/loader.rs"]
@@ -10,6 +11,11 @@ mod loader;
 mod error;
 
 fn main() {
+    build_metadata_database();
+    build_carrier_data();
+}
+
+fn build_metadata_database() {
     let pnm_path = "assets/PhoneNumberMetadata.xml";
     let metadata = loader::load(BufReader::new(
         File::open(pnm_path).expect("could not open metadata file"),
@@ -23,4 +29,91 @@ fn main() {
     );
 
     postcard::to_io(&metadata, &mut out).expect("failed to serialize database");
+}
+
+fn build_carrier_data() {
+    let carrier_dir = Path::new("assets/carrier");
+    // Watch the carrier directory for structural changes.
+    println!("cargo:rerun-if-changed=assets/carrier");
+
+    // prefix → { lang → name }
+    let mut entries: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut max_prefix_len: usize = 0;
+
+    if !carrier_dir.is_dir() {
+        // Write empty data if carrier directory is missing.
+        let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("carrier_data.bin");
+        type CarrierEntries = Vec<(String, Vec<(String, String)>)>;
+        let empty: (CarrierEntries, usize) = (Vec::new(), 0);
+        let mut out =
+            BufWriter::new(File::create(&out_path).expect("could not create carrier data file"));
+        postcard::to_io(&empty, &mut out).expect("failed to serialize carrier data");
+        return;
+    }
+
+    // Walk each language directory: assets/carrier/en/, assets/carrier/zh/, etc.
+    let mut lang_dirs: Vec<_> = fs::read_dir(carrier_dir)
+        .expect("could not read carrier directory")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    lang_dirs.sort_by_key(|e| e.file_name());
+
+    for lang_entry in lang_dirs {
+        let lang = lang_entry.file_name().to_string_lossy().to_string();
+        let lang_path = lang_entry.path();
+
+        let mut txt_files: Vec<_> = fs::read_dir(&lang_path)
+            .unwrap_or_else(|e| panic!("could not read {}: {e}", lang_path.display()))
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "txt")
+                    .unwrap_or(false)
+            })
+            .map(|e| e.path())
+            .collect();
+        txt_files.sort();
+
+        for path in txt_files {
+            println!("cargo:rerun-if-changed={}", path.display());
+            let file = BufReader::new(File::open(&path).unwrap_or_else(|e| {
+                panic!("could not open {}: {e}", path.display())
+            }));
+            for line in file.lines() {
+                let line = line.expect("could not read line");
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                if let Some((prefix, name)) = line.split_once('|') {
+                    let prefix = prefix.trim();
+                    let name = name.trim();
+                    if !prefix.is_empty() && prefix.bytes().all(|b| b.is_ascii_digit()) {
+                        max_prefix_len = max_prefix_len.max(prefix.len());
+                        entries
+                            .entry(prefix.to_string())
+                            .or_default()
+                            .insert(lang.clone(), name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Serialize as Vec<(prefix, Vec<(lang, name)>)> for postcard.
+    let serializable: Vec<(String, Vec<(String, String)>)> = entries
+        .into_iter()
+        .map(|(prefix, langs)| {
+            let lang_vec: Vec<(String, String)> = langs.into_iter().collect();
+            (prefix, lang_vec)
+        })
+        .collect();
+
+    let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("carrier_data.bin");
+    let mut out =
+        BufWriter::new(File::create(&out_path).expect("could not create carrier data file"));
+    postcard::to_io(&(&serializable, max_prefix_len), &mut out)
+        .expect("failed to serialize carrier data");
 }

--- a/src/carrier_mapper.rs
+++ b/src/carrier_mapper.rs
@@ -191,7 +191,10 @@ mod tests {
 
     #[test]
     fn fr_orange() {
-        assert_eq!(name_for_number(&parsed("+33788000000"), "en"), Some("Orange France"));
+        assert_eq!(
+            name_for_number(&parsed("+33788000000"), "en"),
+            Some("Orange France")
+        );
     }
 
     #[test]
@@ -201,19 +204,28 @@ mod tests {
 
     #[test]
     fn fr_free() {
-        assert_eq!(name_for_number(&parsed("+33600000000"), "en"), Some("Free Mobile"));
+        assert_eq!(
+            name_for_number(&parsed("+33600000000"), "en"),
+            Some("Free Mobile")
+        );
     }
 
     #[test]
     fn fr_bouygues() {
-        assert_eq!(name_for_number(&parsed("+33650000000"), "en"), Some("Bouygues"));
+        assert_eq!(
+            name_for_number(&parsed("+33650000000"), "en"),
+            Some("Bouygues")
+        );
     }
 
     // ---- Overlapping prefixes (longest wins) ----
 
     #[test]
     fn overlap_afone_over_orange() {
-        assert_eq!(name_for_number(&parsed("+33780123456"), "en"), Some("Afone"));
+        assert_eq!(
+            name_for_number(&parsed("+33780123456"), "en"),
+            Some("Afone")
+        );
     }
 
     #[test]
@@ -244,12 +256,18 @@ mod tests {
 
     #[test]
     fn belgium_proximus() {
-        assert_eq!(name_for_number(&parsed("+32470000000"), "en"), Some("Proximus"));
+        assert_eq!(
+            name_for_number(&parsed("+32470000000"), "en"),
+            Some("Proximus")
+        );
     }
 
     #[test]
     fn romania_vodafone() {
-        assert_eq!(name_for_number(&parsed("+40721234567"), "en"), Some("Vodafone"));
+        assert_eq!(
+            name_for_number(&parsed("+40721234567"), "en"),
+            Some("Vodafone")
+        );
     }
 
     #[test]
@@ -267,7 +285,10 @@ mod tests {
 
     #[test]
     fn spain_vodafone() {
-        assert_eq!(name_for_number(&parsed("+34666777888"), "en"), Some("Vodafone"));
+        assert_eq!(
+            name_for_number(&parsed("+34666777888"), "en"),
+            Some("Vodafone")
+        );
     }
 
     #[test]

--- a/src/carrier_mapper.rs
+++ b/src/carrier_mapper.rs
@@ -1,0 +1,466 @@
+//! Carrier name lookup from libphonenumber prefix data.
+//!
+//! This module provides carrier name resolution using the same prefix-matching
+//! algorithm as Google's libphonenumber. The carrier data files in
+//! `assets/carrier/` are compiled into a binary blob at build time and embedded
+//! in the crate.
+//!
+//! Carrier data is available in multiple languages. The lookup functions accept
+//! a language code (e.g. `"en"`, `"zh"`, `"zh_Hant"`) and fall back to English
+//! when no translation is available (except for Chinese, Japanese, and Korean).
+//!
+//! # Example
+//!
+//! ```
+//! use phonenumber::carrier_mapper;
+//!
+//! let number = phonenumber::parse(None, "+33788439407").unwrap();
+//! assert_eq!(carrier_mapper::name_for_number(&number, "en"), Some("Orange France"));
+//! ```
+
+use crate::metadata::DATABASE;
+use crate::PhoneNumber;
+use crate::Type;
+use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
+
+const CARRIER_DATA_BIN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/carrier_data.bin"));
+
+struct CarrierDatabase {
+    /// prefix → { lang → carrier name }
+    entries: FnvHashMap<String, FnvHashMap<String, String>>,
+    max_prefix_len: usize,
+}
+
+static DB: Lazy<CarrierDatabase> = Lazy::new(|| {
+    type CarrierEntries = Vec<(String, Vec<(String, String)>)>;
+    let (entries_vec, max_prefix_len): (CarrierEntries, usize) =
+        postcard::from_bytes(CARRIER_DATA_BIN).expect("failed to deserialize carrier data");
+    let entries: FnvHashMap<String, FnvHashMap<String, String>> = entries_vec
+        .into_iter()
+        .map(|(prefix, langs)| (prefix, langs.into_iter().collect()))
+        .collect();
+    CarrierDatabase {
+        entries,
+        max_prefix_len,
+    }
+});
+
+/// Locale normalization map, matching libphonenumber behavior.
+fn normalize_locale(locale: &str) -> Option<&'static str> {
+    match locale {
+        "zh_TW" | "zh_HK" | "zh_MO" => Some("zh_Hant"),
+        _ => None,
+    }
+}
+
+/// Returns `false` for Chinese, Japanese, and Korean — these languages do not
+/// fall back to English when no translation is available.
+fn may_fall_back_to_english(lang: &str) -> bool {
+    lang != "zh" && lang != "ja" && lang != "ko"
+}
+
+/// Look up the best available translation in a per-prefix language map.
+///
+/// Follows the libphonenumber locale resolution order:
+/// 1. Normalized full locale (e.g. `zh_TW` → `zh_Hant`)
+/// 2. Full locale as provided
+/// 3. Language + script (if the locale contains both)
+/// 4. Language + region
+/// 5. Bare language code
+/// 6. English fallback (except for zh, ja, ko)
+fn find_lang<'a>(lang_map: &'a FnvHashMap<String, String>, locale: &str) -> Option<&'a str> {
+    // Check normalization map.
+    if let Some(normalized) = normalize_locale(locale) {
+        if let Some(name) = lang_map.get(normalized) {
+            return Some(name.as_str());
+        }
+    }
+
+    // Full locale as-is.
+    if let Some(name) = lang_map.get(locale) {
+        return Some(name.as_str());
+    }
+
+    // Extract the bare language code (first component before '_').
+    let lang = locale.split('_').next().unwrap_or(locale);
+
+    // If the locale has multiple parts, try progressively shorter variants.
+    let parts: Vec<&str> = locale.splitn(3, '_').collect();
+    if parts.len() == 3 {
+        // Try lang_script (e.g. "zh_Hant" from "zh_Hant_TW").
+        let lang_script = format!("{}_{}", parts[0], parts[1]);
+        if let Some(name) = lang_map.get(&lang_script) {
+            return Some(name.as_str());
+        }
+        // Try lang_region (e.g. "zh_TW" from "zh_Hant_TW").
+        let lang_region = format!("{}_{}", parts[0], parts[2]);
+        if let Some(name) = lang_map.get(&lang_region) {
+            return Some(name.as_str());
+        }
+    }
+
+    // Bare language.
+    if lang != locale {
+        if let Some(name) = lang_map.get(lang) {
+            return Some(name.as_str());
+        }
+    }
+
+    // English fallback (not for CJK).
+    if may_fall_back_to_english(lang) {
+        if let Some(name) = lang_map.get("en") {
+            return Some(name.as_str());
+        }
+    }
+
+    None
+}
+
+/// Returns the carrier name for a valid phone number in the given language.
+///
+/// This skips the number type check — the caller is responsible for ensuring
+/// the number is suitable for carrier lookup (mobile, fixed-line-or-mobile,
+/// or pager).
+///
+/// Returns `None` if no carrier data exists for this number's prefix.
+pub fn name_for_valid_number(number: &PhoneNumber, lang: &str) -> Option<&'static str> {
+    let e164 = format!("{}{}", number.code().value(), number.national());
+    let db = &*DB;
+
+    let max = db.max_prefix_len.min(e164.len());
+    for len in (1..=max).rev() {
+        if let Some(lang_map) = db.entries.get(&e164[..len]) {
+            return find_lang(lang_map, lang);
+        }
+    }
+    None
+}
+
+/// Returns the carrier name for a phone number in the given language.
+///
+/// Carrier lookup only applies to mobile, fixed-line-or-mobile, and pager
+/// numbers. For other types, this returns `None`.
+///
+/// The carrier name is the one the number was **originally allocated to**.
+/// In countries with mobile number portability, the number may have been
+/// ported to a different carrier.
+///
+/// Falls back to English when no translation exists for the requested
+/// language, except for Chinese, Japanese, and Korean.
+pub fn name_for_number(number: &PhoneNumber, lang: &str) -> Option<&'static str> {
+    let ntype = number.number_type(&DATABASE);
+    if is_carrier_type(ntype) {
+        name_for_valid_number(number, lang)
+    } else {
+        None
+    }
+}
+
+/// Returns the carrier name only when it is safe to display to users.
+///
+/// A carrier name is considered safe if the number's country does **not**
+/// support mobile number portability. In countries with portability (most
+/// of Europe, US, Brazil, etc.), the originally allocated carrier may no
+/// longer be accurate, so this function returns `None`.
+///
+/// See <https://en.wikipedia.org/wiki/Mobile_number_portability>.
+pub fn safe_display_name(number: &PhoneNumber, lang: &str) -> Option<&'static str> {
+    if let Some(meta) = number.metadata(&DATABASE) {
+        if meta.is_mobile_number_portable() {
+            return None;
+        }
+    }
+    name_for_number(number, lang)
+}
+
+fn is_carrier_type(ntype: Type) -> bool {
+    matches!(ntype, Type::Mobile | Type::FixedLineOrMobile | Type::Pager)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser;
+
+    fn parsed(s: &str) -> PhoneNumber {
+        parser::parse(None, s).unwrap()
+    }
+
+    // ---- French carriers (basic, English) ----
+
+    #[test]
+    fn fr_orange() {
+        assert_eq!(name_for_number(&parsed("+33788000000"), "en"), Some("Orange France"));
+    }
+
+    #[test]
+    fn fr_sfr() {
+        assert_eq!(name_for_number(&parsed("+33601000000"), "en"), Some("SFR"));
+    }
+
+    #[test]
+    fn fr_free() {
+        assert_eq!(name_for_number(&parsed("+33600000000"), "en"), Some("Free Mobile"));
+    }
+
+    #[test]
+    fn fr_bouygues() {
+        assert_eq!(name_for_number(&parsed("+33650000000"), "en"), Some("Bouygues"));
+    }
+
+    // ---- Overlapping prefixes (longest wins) ----
+
+    #[test]
+    fn overlap_afone_over_orange() {
+        assert_eq!(name_for_number(&parsed("+33780123456"), "en"), Some("Afone"));
+    }
+
+    #[test]
+    fn overlap_laposte_over_orange() {
+        assert_eq!(
+            name_for_number(&parsed("+33784612345"), "en"),
+            Some("La poste telecom")
+        );
+    }
+
+    #[test]
+    fn overlap_lebara_over_afone_over_orange() {
+        assert_eq!(
+            name_for_number(&parsed("+33780712345"), "en"),
+            Some("Lebara France Limited")
+        );
+    }
+
+    #[test]
+    fn fallback_to_shortest_when_no_longer_match() {
+        assert_eq!(
+            name_for_number(&parsed("+33789000000"), "en"),
+            Some("Orange France")
+        );
+    }
+
+    // ---- International carriers ----
+
+    #[test]
+    fn belgium_proximus() {
+        assert_eq!(name_for_number(&parsed("+32470000000"), "en"), Some("Proximus"));
+    }
+
+    #[test]
+    fn romania_vodafone() {
+        assert_eq!(name_for_number(&parsed("+40721234567"), "en"), Some("Vodafone"));
+    }
+
+    #[test]
+    fn hong_kong_china_mobile() {
+        assert_eq!(
+            name_for_number(&parsed("+85244012345"), "en"),
+            Some("China Mobile")
+        );
+    }
+
+    #[test]
+    fn uk_jersey_telecom() {
+        assert_eq!(name_for_number(&parsed("+447911123456"), "en"), Some("JT"));
+    }
+
+    #[test]
+    fn spain_vodafone() {
+        assert_eq!(name_for_number(&parsed("+34666777888"), "en"), Some("Vodafone"));
+    }
+
+    #[test]
+    fn italy_tim() {
+        assert_eq!(name_for_number(&parsed("+393331234567"), "en"), Some("TIM"));
+    }
+
+    #[test]
+    fn brazil_vivo() {
+        assert_eq!(
+            name_for_number(&parsed("+5511954720000"), "en"),
+            Some("Vivo")
+        );
+    }
+
+    // ---- Multi-language support ----
+
+    #[test]
+    fn chinese_carrier_in_chinese() {
+        // China Unicom in Simplified Chinese
+        assert_eq!(
+            name_for_number(&parsed("+8613000000000"), "zh"),
+            Some("中国联通")
+        );
+    }
+
+    #[test]
+    fn chinese_carrier_in_english() {
+        assert_eq!(
+            name_for_number(&parsed("+8613000000000"), "en"),
+            Some("China Unicom")
+        );
+    }
+
+    #[test]
+    fn chinese_no_english_fallback() {
+        // zh does NOT fall back to English for numbers without zh data
+        // FR numbers have no Chinese translation
+        assert_eq!(name_for_number(&parsed("+33788000000"), "zh"), None);
+    }
+
+    #[test]
+    fn korean_no_english_fallback() {
+        // ko does NOT fall back to English for numbers without ko data
+        assert_eq!(name_for_number(&parsed("+33788000000"), "ko"), None);
+    }
+
+    #[test]
+    fn french_falls_back_to_english() {
+        // "fr" is not in the carrier data — should fall back to "en"
+        assert_eq!(
+            name_for_number(&parsed("+33788000000"), "fr"),
+            Some("Orange France")
+        );
+    }
+
+    #[test]
+    fn russian_carrier_in_russian() {
+        assert_eq!(
+            name_for_number(&parsed("+79200000000"), "ru"),
+            Some("МегаФон")
+        );
+    }
+
+    #[test]
+    fn russian_carrier_in_english() {
+        assert_eq!(
+            name_for_number(&parsed("+79200000000"), "en"),
+            Some("MegaFon")
+        );
+    }
+
+    // ---- Locale normalization ----
+
+    #[test]
+    fn zh_tw_normalizes_to_zh_hant() {
+        // zh_TW should be normalized to zh_Hant
+        let n = parsed("+8613000000000");
+        let result_hant = name_for_number(&n, "zh_Hant");
+        let result_tw = name_for_number(&n, "zh_TW");
+        assert_eq!(result_hant, result_tw);
+    }
+
+    #[test]
+    fn zh_hk_normalizes_to_zh_hant() {
+        let n = parsed("+8613000000000");
+        let result_hant = name_for_number(&n, "zh_Hant");
+        let result_hk = name_for_number(&n, "zh_HK");
+        assert_eq!(result_hant, result_hk);
+    }
+
+    // ---- Type filtering ----
+
+    #[test]
+    fn fixed_line_rejected() {
+        assert_eq!(name_for_number(&parsed("+4930123456"), "en"), None);
+    }
+
+    #[test]
+    fn toll_free_international_rejected() {
+        assert_eq!(name_for_number(&parsed("+80012340000"), "en"), None);
+    }
+
+    #[test]
+    fn toll_free_french_rejected() {
+        assert_eq!(name_for_number(&parsed("+33800123456"), "en"), None);
+    }
+
+    #[test]
+    fn us_no_carrier_data() {
+        assert_eq!(name_for_number(&parsed("+12025551234"), "en"), None);
+    }
+
+    // ---- name_for_valid_number bypasses type check ----
+
+    #[test]
+    fn valid_number_skips_type_filter() {
+        let n = parsed("+4930123456");
+        let _ = name_for_valid_number(&n, "en");
+    }
+
+    // ---- safe_display_name ----
+
+    #[test]
+    fn safe_display_returns_none_for_portable_country() {
+        // France supports mobile portability → safe_display_name returns None
+        let n = parsed("+33788000000");
+        assert_eq!(safe_display_name(&n, "en"), None);
+    }
+
+    #[test]
+    fn safe_display_returns_none_for_us() {
+        // US supports mobile portability
+        let n = parsed("+12025551234");
+        assert_eq!(safe_display_name(&n, "en"), None);
+    }
+
+    // ---- Database sanity checks ----
+
+    #[test]
+    fn database_is_loaded() {
+        let db = &*DB;
+        assert!(
+            db.entries.len() > 20_000,
+            "expected >20K entries, got {}",
+            db.entries.len()
+        );
+    }
+
+    #[test]
+    fn max_prefix_len_is_reasonable() {
+        let db = &*DB;
+        assert!(
+            db.max_prefix_len >= 7 && db.max_prefix_len <= 12,
+            "unexpected max_prefix_len: {}",
+            db.max_prefix_len
+        );
+    }
+
+    // ---- is_carrier_type ----
+
+    #[test]
+    fn carrier_type_mobile() {
+        assert!(is_carrier_type(Type::Mobile));
+    }
+
+    #[test]
+    fn carrier_type_fixed_line_or_mobile() {
+        assert!(is_carrier_type(Type::FixedLineOrMobile));
+    }
+
+    #[test]
+    fn carrier_type_pager() {
+        assert!(is_carrier_type(Type::Pager));
+    }
+
+    #[test]
+    fn not_carrier_type_fixed_line() {
+        assert!(!is_carrier_type(Type::FixedLine));
+    }
+
+    #[test]
+    fn not_carrier_type_toll_free() {
+        assert!(!is_carrier_type(Type::TollFree));
+    }
+
+    #[test]
+    fn not_carrier_type_voip() {
+        assert!(!is_carrier_type(Type::Voip));
+    }
+
+    #[test]
+    fn not_carrier_type_premium() {
+        assert!(!is_carrier_type(Type::PremiumRate));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub use crate::extension::Extension;
 mod carrier;
 pub use crate::carrier::Carrier;
 
+/// Carrier name lookup from libphonenumber prefix data.
+pub mod carrier_mapper;
+
 mod phone_number;
 pub use crate::phone_number::{PhoneNumber, Type};
 


### PR DESCRIPTION
## Summary

- Add `carrier_mapper` module that resolves carrier names from the existing `assets/carrier/` prefix data compiled at build time
- Longest-prefix matching algorithm consistent with libphonenumber's Java implementation
- Multi-language support (10 languages) with locale fallback (`zh_TW` → `zh_Hant`, CJK does not fall back to English)

## Public API

- `carrier_mapper::name_for_number(number, lang)` — carrier name with number-type filtering (mobile, fixed-line-or-mobile, pager)
- `carrier_mapper::name_for_valid_number(number, lang)` — carrier name without type check
- `carrier_mapper::safe_display_name(number, lang)` — carrier name only for countries without mobile number portability

## Changes

- `src/carrier_mapper.rs` — new module (3 public functions, locale resolution, 40 unit tests)
- `build.rs` — add `build_carrier_data()` to compile `assets/carrier/` txt files into a binary blob via postcard
- `src/lib.rs` — expose `carrier_mapper` module
- `README.md` — add carrier lookup example

No data files were modified. This only adds code to use the carrier data that is already shipped with the crate.

## Test plan

- [x] `cargo test` — 134 existing tests pass, 40 new carrier tests pass, 2 doctests pass
- [x] `cargo clippy` — no warnings
- [x] Cross-validated results against Python phonenumbers on 19 test numbers
- [x] Verified carrier data is identical to official libphonenumber v9.0.21