### PR TITLE
Remove Regex Cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ nom = "7.1"
 postcard = "1.1"
 quick-xml = ">=0.28, <= 0.38"
 regex = "1.7"
-regex-cache = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 strum = { version = ">=0.24, <=0.27", features = ["derive"] }

--- a/src/metadata/database.rs
+++ b/src/metadata/database.rs
@@ -17,13 +17,13 @@ use crate::metadata::loader;
 use crate::Metadata;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
-use regex_cache::{CachedRegex, CachedRegexBuilder, RegexCache};
+use regex::{Regex, RegexBuilder};
 use std::borrow::Borrow;
 use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufReader, Cursor};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 const DATABASE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/database.bin"));
 
@@ -34,7 +34,6 @@ pub static DEFAULT: Lazy<Database> =
 /// Representation of a database of metadata for phone number.
 #[derive(Clone, Debug)]
 pub struct Database {
-    cache: Arc<Mutex<RegexCache>>,
     by_id: FnvHashMap<String, Arc<super::Metadata>>,
     by_code: FnvHashMap<u16, Vec<Arc<super::Metadata>>>,
     regions: FnvHashMap<u16, Vec<String>>,
@@ -63,11 +62,8 @@ impl Database {
             }
         }
 
-        let cache = Arc::new(Mutex::new(RegexCache::new(100)));
-        let regex = |value: String| -> Result<CachedRegex, error::LoadMetadata> {
-            Ok(CachedRegexBuilder::new(cache.clone(), &value)
-                .ignore_whitespace(true)
-                .build()?)
+        let regex = |value: String| -> Result<Regex, error::LoadMetadata> {
+            Ok(RegexBuilder::new(&value).ignore_whitespace(true).build()?)
         };
 
         let descriptor =
@@ -212,16 +208,10 @@ impl Database {
         }
 
         Ok(Database {
-            cache: cache.clone(),
             by_id,
             by_code,
             regions,
         })
-    }
-
-    /// Get the regular expression cache.
-    pub fn cache(&self) -> Arc<Mutex<RegexCache>> {
-        self.cache.clone()
     }
 
     /// Get a metadata entry by country ID.

--- a/src/metadata/descriptor.rs
+++ b/src/metadata/descriptor.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use regex_cache::CachedRegex;
+use regex::Regex;
 
 /// Description of a phone number to parse.
 #[derive(Clone, Debug)]
 pub struct Descriptor {
-    pub(crate) national_number: CachedRegex,
+    pub(crate) national_number: Regex,
 
     pub(crate) possible_length: Vec<u16>,
     pub(crate) possible_local_length: Vec<u16>,
@@ -29,7 +29,7 @@ impl Descriptor {
     /// The national number is the pattern that a valid national significant
     /// number would match. This specifies information such as its total length
     /// and leading digits.
-    pub fn national_number(&self) -> &CachedRegex {
+    pub fn national_number(&self) -> &Regex {
         &self.national_number
     }
 

--- a/src/metadata/format.rs
+++ b/src/metadata/format.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use regex_cache::CachedRegex;
+use regex::Regex;
 
 /// Description of a phone number format.
 #[derive(Clone, Debug)]
 pub struct Format {
-    pub(crate) pattern: CachedRegex,
+    pub(crate) pattern: Regex,
     pub(crate) format: String,
 
-    pub(crate) leading_digits: Vec<CachedRegex>,
+    pub(crate) leading_digits: Vec<Regex>,
     pub(crate) national_prefix: Option<String>,
     pub(crate) national_prefix_optional: bool,
     pub(crate) domestic_carrier: Option<String>,
@@ -33,7 +33,7 @@ impl Format {
     ///
     /// Note the presence of the parentheses, which are capturing groups what
     /// specifies the grouping of numbers.
-    pub fn pattern(&self) -> &CachedRegex {
+    pub fn pattern(&self) -> &Regex {
         &self.pattern
     }
 
@@ -63,7 +63,7 @@ impl Format {
     ///
     /// In the case when only one formatting pattern exists, no
     /// leading_digits_pattern is needed.
-    pub fn leading_digits(&self) -> &[CachedRegex] {
+    pub fn leading_digits(&self) -> &[Regex] {
         &self.leading_digits
     }
 

--- a/src/metadata/metadata.rs
+++ b/src/metadata/metadata.rs
@@ -16,7 +16,7 @@ use crate::{
     metadata::{Descriptor, Format},
     phone_number::Type,
 };
-use regex_cache::CachedRegex;
+use regex::Regex;
 
 /// Phone number metadata.
 #[derive(Clone, Debug)]
@@ -25,17 +25,17 @@ pub struct Metadata {
     pub(crate) id: String,
     pub(crate) country_code: u16,
 
-    pub(crate) international_prefix: Option<CachedRegex>,
+    pub(crate) international_prefix: Option<Regex>,
     pub(crate) preferred_international_prefix: Option<String>,
     pub(crate) national_prefix: Option<String>,
     pub(crate) preferred_extension_prefix: Option<String>,
-    pub(crate) national_prefix_for_parsing: Option<CachedRegex>,
+    pub(crate) national_prefix_for_parsing: Option<Regex>,
     pub(crate) national_prefix_transform_rule: Option<String>,
 
     pub(crate) formats: Vec<Format>,
     pub(crate) international_formats: Vec<Format>,
     pub(crate) main_country_for_code: bool,
-    pub(crate) leading_digits: Option<CachedRegex>,
+    pub(crate) leading_digits: Option<Regex>,
     pub(crate) mobile_number_portable: bool,
 }
 
@@ -87,7 +87,7 @@ impl Metadata {
     /// by the country code for country B. Note that some countries may have more
     /// than one international prefix, and for those cases, a regular expression
     /// matching the international prefixes will be stored in this field.
-    pub fn international_prefix(&self) -> Option<&CachedRegex> {
+    pub fn international_prefix(&self) -> Option<&Regex> {
         self.international_prefix.as_ref()
     }
 
@@ -132,7 +132,7 @@ impl Metadata {
     ///
     /// When it is missing from the XML file, this field inherits the value of
     /// national prefix, if that is present.
-    pub fn national_prefix_for_parsing(&self) -> Option<&CachedRegex> {
+    pub fn national_prefix_for_parsing(&self) -> Option<&Regex> {
         self.national_prefix_for_parsing.as_ref()
     }
 
@@ -221,7 +221,7 @@ impl Metadata {
     /// It is used merely as a short-cut for working out which region a number
     /// comes from in the case that there is only one, so leading digit prefixes
     /// should not overlap.
-    pub fn leading_digits(&self) -> Option<&CachedRegex> {
+    pub fn leading_digits(&self) -> Option<&Regex> {
         self.leading_digits.as_ref()
     }
 

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -26,7 +26,7 @@ use nom::{
     multi::*,
     AsChar, IResult,
 };
-use regex_cache::CachedRegex;
+use regex::Regex;
 use std::borrow::Cow;
 
 macro_rules! parse {
@@ -211,7 +211,7 @@ pub fn country_code<'a>(
 ///
 /// Note that since the IDD comes from a passed default region, we can find the
 /// country code from the given default if the country source is from the IDD.
-pub fn international_prefix<'a>(idd: Option<&CachedRegex>, mut number: Number<'a>) -> Number<'a> {
+pub fn international_prefix<'a>(idd: Option<&Regex>, mut number: Number<'a>) -> Number<'a> {
     // If there's a prefix already, i.e. RFC3966, just change the country source.
     if number.prefix.is_some() {
         number.country = country::Source::Plus;
@@ -438,6 +438,7 @@ mod test {
     use crate::metadata::DATABASE;
     use crate::parser::helper;
     use crate::parser::helper::*;
+    use regex::Regex;
 
     #[test]
     fn punctuation() {
@@ -700,7 +701,7 @@ mod test {
                 ..Default::default()
             },
             helper::international_prefix(
-                Some(&CachedRegex::new(DATABASE.cache(), "00[39]").unwrap()),
+                Some(&Regex::new("00[39]").unwrap()),
                 Number {
                     national: "0034567700-3898003".into(),
 
@@ -717,7 +718,7 @@ mod test {
                 ..Default::default()
             },
             helper::international_prefix(
-                Some(&CachedRegex::new(DATABASE.cache(), "00[39]").unwrap()),
+                Some(&Regex::new("00[39]").unwrap()),
                 Number {
                     national: "00945677003898003".into(),
 
@@ -734,7 +735,7 @@ mod test {
                 ..Default::default()
             },
             helper::international_prefix(
-                Some(&CachedRegex::new(DATABASE.cache(), "00[39]").unwrap()),
+                Some(&Regex::new("00[39]").unwrap()),
                 Number {
                     national: "00 9 45677003898003".into(),
 
@@ -750,7 +751,7 @@ mod test {
                 ..Default::default()
             },
             helper::international_prefix(
-                Some(&CachedRegex::new(DATABASE.cache(), "00[39]").unwrap()),
+                Some(&Regex::new("00[39]").unwrap()),
                 Number {
                     national: "45677003898003".into(),
 
@@ -767,7 +768,7 @@ mod test {
                 ..Default::default()
             },
             helper::international_prefix(
-                Some(&CachedRegex::new(DATABASE.cache(), "00[39]").unwrap()),
+                Some(&Regex::new("00[39]").unwrap()),
                 Number {
                     national: "+45677003898003".into(),
 


### PR DESCRIPTION
These changes swap the use of a cached regex with the normal regex implementations to allow for concurrency.