### PR TITLE
chore: allow quick-xml 0.41 to fix RUSTSEC advisories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ fnv = "1"
 once_cell = "1"
 nom = "7.1"
 postcard = "1.1"
-quick-xml = ">=0.28, <= 0.40"
+quick-xml = ">=0.28, <=0.41"
 regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"
@@ -27,7 +27,7 @@ thiserror = "2.0"
 
 [build-dependencies]
 postcard = { version = "1.1", features = ["use-std"] }
-quick-xml = ">=0.28, <=0.40"
+quick-xml = ">=0.28, <=0.41"
 regex = "1.7"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Widens the `quick-xml` version bound from `<=0.40` to `<=0.41` in both `[dependencies]` and `[build-dependencies]`.

`quick-xml 0.40` is affected by two denial-of-service advisories, both patched in `0.41.0`:
- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic run time when checking a start tag for duplicate attribute names.
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) — unbounded namespace-declaration allocation in `NsReader`.

With the current `<=0.40` cap, downstreams can't resolve to the fixed release. `quick-xml` is only used here to parse the bundled, trusted metadata XML at build time, so the DoS isn't reachable in practice — but the cap still blocks consumers from clearing the advisory, and `cargo deny` fails for them.

No source changes are needed — the crate builds and the full test suite passes against `quick-xml 0.41.0`:
- `cargo build` — clean.
- `cargo test` — 90 passed / 0 failed (plus the integration/doc suites).
- `cargo fmt --check` — clean.